### PR TITLE
Add `next` and `throw` capabilities to `handleActions`

### DIFF
--- a/redux-actions/redux-actions.d.ts
+++ b/redux-actions/redux-actions.d.ts
@@ -17,13 +17,18 @@ declare module ReduxActions {
 
     type Reducer<T> = (state: T, action: Action) => T;
 
+    type ReducerNextThrow<T> {
+        next: Reducer<T>;
+        throw: Reducer<T>;
+    };
+    
     type ReducerMap<T> = {
-        [actionType: string]: Reducer<T>
+        [actionType: string]: Reducer<T> | ReducerNextThrow<T>
     };
 
     export function createAction<T>(actionType: string, payloadCreator?: PayloadCreator<T>, metaCreator?: MetaCreator): (...args: any[]) => Action;
 
-    export function handleAction<T>(actionType: string, reducer: Reducer<T> | ReducerMap<T>): Reducer<T>;
+    export function handleAction<T>(actionType: string, reducer: Reducer<T> | ReducerNextThrow<T>): Reducer<T>;
 
     export function handleActions<T>(reducerMap: ReducerMap<T>, initialState?: T): Reducer<T>;
 }


### PR DESCRIPTION
Hi!
    It looks like `handleActions` also accepts the `throw`, `next` idiom, the same as `handleAction`.

In this PR I update the typings so that `ReducerMap` accepts `Reducer` and `ReducerNextThrow` as values and also I renamed the type that `handleAction` uses.


Im not particularly happy with the name `ReducerNextThrow` but couldn't figure out any better, so Im open to suggestions.

Thanks!

You can check an issue about it https://github.com/acdlite/redux-actions/issues/102

You can check the source here: https://github.com/acdlite/redux-actions/blob/master/src/handleActions.js#L6