### PR TITLE
markerclustererplus : Fixed signature for setCalculator function

### DIFF
--- a/markerclustererplus/markerclustererplus.d.ts
+++ b/markerclustererplus/markerclustererplus.d.ts
@@ -598,7 +598,7 @@ interface MarkerClusterer extends google.maps.OverlayView {
      * @param {function(Array.<google.maps.Marker>, number)} calculator The value
      *  of the calculator property.
      */
-   setCalculator(calculator: (marker: google.maps.Marker, value: number) => Function): void;
+   setCalculator(calculator: (markers: google.maps.Marker[], value: number) => ClusterIconInfo): void;
    
    /**
      * Sets the value of the <code>hideLabel</code> property.


### PR DESCRIPTION
Hi,

the CALCULATOR has such signature:

```javascript
CALCULATOR(markers: google.maps.Marker[], numStyles: number): ClusterIconInfo;
```
I suppose that setting calculator should take same signature function

```javascript
setCalculator(calculator: (markers: google.maps.Marker[], value: number) => ClusterIconInfo): void;
```
  
Thanks 